### PR TITLE
Use python3 when calling the amalgamate script

### DIFF
--- a/amalLibs/CMakeLists.txt
+++ b/amalLibs/CMakeLists.txt
@@ -96,7 +96,7 @@ set(ENV{CXX} ${CMAKE_CXX_COMPILER})     ## Botan configure.py uses CXX to detect
 
 ## Run Botan configure to create the amalgamation files, then move them to
 ## build directory and remove artifacts
-execute_process(COMMAND python ${configCommand}
+execute_process(COMMAND python3 ${configCommand}
         WORKING_DIRECTORY ${TOP_DIR}
         RESULT_VARIABLE result
         OUTPUT_VARIABLE stdOut


### PR DESCRIPTION
Uses `python3` instead of `python` when executing the amalgamate script
in the `CMakeLists.txt` file.